### PR TITLE
Include trailing commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Install via `Lazy`:
 ```lua
 -- lazy
 {
-    "askfiy/visual_studio_code"
+    "askfiy/visual_studio_code",
     priority = 100,
     config = function()
         require("visual_studio_code").setup({
             mode = "dark",
         })
     end,
-}
+},
 ```
 
 Install via `Packer`:


### PR DESCRIPTION
Make lazy config easier to paste into init.lua. 

I tried to copy/paste this into my `init.lua` and the initial missing trailing comma was causing a syntax error:

```
Dotfiles/nvim/init.lua:30: '}' expected (to close '{' at line 28) near 'priority'
```